### PR TITLE
add scripts to build a docker image

### DIFF
--- a/php/mkimage-arch-pacman.conf
+++ b/php/mkimage-arch-pacman.conf
@@ -1,0 +1,26 @@
+[options]
+Architecture = auto
+SigLevel    = Required DatabaseOptional
+LocalFileSigLevel = Optional
+#RemoteFileSigLevel = Required
+
+[core]
+Include = /etc/pacman.d/mirrorlist
+
+[extra]
+Include = /etc/pacman.d/mirrorlist
+
+[community]
+Include = /etc/pacman.d/mirrorlist
+
+[multilib]
+Include = /etc/pacman.d/mirrorlist
+
+[oracle]
+SigLevel = Optional TrustAll
+Server = http://linux.shikadi.net/arch/$repo/$arch/
+
+[niix]
+SigLevel = Optional TrustAll
+Server = http://niix.pl/arch/$repo/$arch/
+

--- a/php/mkimage-arch.sh
+++ b/php/mkimage-arch.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Generate a minimal filesystem for archlinux and load it into the local
+# docker as "archlinux"
+# requires root
+set -e
+
+hash pacstrap &>/dev/null || {
+	echo "Could not find pacstrap. Run pacman -S arch-install-scripts"
+	exit 1
+}
+
+hash expect &>/dev/null || {
+	echo "Could not find expect. Run pacman -S expect"
+	exit 1
+}
+
+export LANG="C.UTF-8"
+
+ROOTFS=$(mktemp -d ${TMPDIR:-/var/tmp}/rootfs-archlinux-XXXXXXXXXX)
+chmod 755 $ROOTFS
+
+# packages to ignore for space savings
+PKGIGNORE=(
+    cryptsetup
+    device-mapper
+    dhcpcd
+    iproute2
+    jfsutils
+    linux
+    lvm2
+    man-db
+    man-pages
+    mdadm
+    nano
+    netctl
+    openresolv
+    pciutils
+    pcmciautils
+    reiserfsprogs
+    s-nail
+    systemd-sysvcompat
+    usbutils
+    vi
+    xfsprogs
+)
+IFS=','
+PKGIGNORE="${PKGIGNORE[*]}"
+unset IFS
+
+expect <<EOF
+	set send_slow {1 .1}
+	proc send {ignore arg} {
+		sleep .1
+		exp_send -s -- \$arg
+	}
+	set timeout 600
+
+	spawn pacstrap -C ./mkimage-arch-pacman.conf -c -d -G -i $ROOTFS base haveged oracle-instantclient-basic php-oci8 oracle-xe --ignore $PKGIGNORE
+	expect {
+		-exact "anyway? \[Y/n\] " { send -- "n\r"; exp_continue }
+		-exact "(default=all): " { send -- "\r"; exp_continue }
+		-exact "installation? \[Y/n\]" { send -- "y\r"; exp_continue }
+	}
+EOF
+
+arch-chroot $ROOTFS /bin/sh -c 'rm -r /usr/share/man/*'
+arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill haveged; pacman -Rs --noconfirm haveged; pacman-key --populate archlinux; pkill gpg-agent"
+arch-chroot $ROOTFS /bin/sh -c "ln -s /usr/share/zoneinfo/UTC /etc/localtime"
+echo 'en_US.UTF-8 UTF-8' > $ROOTFS/etc/locale.gen
+arch-chroot $ROOTFS locale-gen
+arch-chroot $ROOTFS /bin/sh -c 'echo "Server = https://mirrors.kernel.org/archlinux/\$repo/os/\$arch" > /etc/pacman.d/mirrorlist'
+
+# configure oracle
+arch-chroot $ROOTFS /bin/sh -c 'echo -e "\n\nyiitest\nyiitest\nn\n" | /etc/rc.d/oracle-xe configure'
+
+cat > $ROOTFS/tmp/createuser_yiitest.sql <<< EOF
+CREATE USER "YIITEST" IDENTIFIED BY 'yiitest' DEFAULT TABLESPACE "USERS" TEMPORARY TABLESPACE "TEMP";
+GRANT "CONNECT" TO "YIITEST";
+GRANT "RESOURCE" TO "YIITEST";
+GRANT CREATE MATERIALIZED VIEW TO "YIITEST";
+GRANT CREATE TRIGGER TO "YIITEST";
+GRANT CREATE PROCEDURE TO "YIITEST";
+GRANT CREATE SEQUENCE TO "YIITEST";
+GRANT CREATE VIEW TO "YIITEST";
+GRANT CREATE SYNONYM TO "YIITEST";
+GRANT CREATE TABLE TO "YIITEST";
+GRANT UNLIMITED TABLESPACE TO "YIITEST";
+GRANT CREATE SESSION TO "YIITEST";
+GRANT ALTER SYSTEM TO "YIITEST";
+EOF
+arch-chroot $ROOTFS /bin/su oracle -c 'cat /tmp/createuser_yiitest.sql | ORACLE_HOME=/usr/lib/oracle/product/11.2.0/xe sqplus -s / as sysdba'
+
+# udev doesn't work in containers, rebuild /dev
+DEV=$ROOTFS/dev
+rm -rf $DEV
+mkdir -p $DEV
+mknod -m 666 $DEV/null c 1 3
+mknod -m 666 $DEV/zero c 1 5
+mknod -m 666 $DEV/random c 1 8
+mknod -m 666 $DEV/urandom c 1 9
+mkdir -m 755 $DEV/pts
+mkdir -m 1777 $DEV/shm
+mknod -m 666 $DEV/tty c 5 0
+mknod -m 600 $DEV/console c 5 1
+mknod -m 666 $DEV/tty0 c 4 0
+mknod -m 666 $DEV/full c 1 7
+mknod -m 600 $DEV/initctl p
+mknod -m 666 $DEV/ptmx c 5 2
+ln -sf /proc/self/fd $DEV/fd
+
+tar --numeric-owner --xattrs --acls -C $ROOTFS -c . | docker import - archlinux
+docker run -t archlinux echo Success.
+rm -rf $ROOTFS

--- a/php/mkimage-arch.sh
+++ b/php/mkimage-arch.sh
@@ -73,7 +73,7 @@ arch-chroot $ROOTFS /bin/sh -c 'echo "Server = https://mirrors.kernel.org/archli
 # configure oracle
 arch-chroot $ROOTFS /bin/sh -c 'echo -e "\n\nyiitest\nyiitest\nn\n" | /etc/rc.d/oracle-xe configure'
 
-cat > $ROOTFS/tmp/createuser_yiitest.sql <<< EOF
+cat > $ROOTFS/tmp/createuser_yiitest.sql << EOF
 CREATE USER "YIITEST" IDENTIFIED BY 'yiitest' DEFAULT TABLESPACE "USERS" TEMPORARY TABLESPACE "TEMP";
 GRANT "CONNECT" TO "YIITEST";
 GRANT "RESOURCE" TO "YIITEST";
@@ -88,7 +88,7 @@ GRANT UNLIMITED TABLESPACE TO "YIITEST";
 GRANT CREATE SESSION TO "YIITEST";
 GRANT ALTER SYSTEM TO "YIITEST";
 EOF
-arch-chroot $ROOTFS /bin/su oracle -c 'cat /tmp/createuser_yiitest.sql | ORACLE_HOME=/usr/lib/oracle/product/11.2.0/xe sqplus -s / as sysdba'
+arch-chroot $ROOTFS /bin/su oracle -c 'cat /tmp/createuser_yiitest.sql | ORACLE_HOME=/usr/lib/oracle/product/11.2.0/xe sqlplus -s / as sysdba'
 
 # udev doesn't work in containers, rebuild /dev
 DEV=$ROOTFS/dev


### PR DESCRIPTION
This script creates a docker image with:
- minimal Arch Linux installation
- oracle-xe database, sysdba password is set to `yiitest` and a `yiitest` user with same password is created
- oci8 PHP module, enabled in php.ini; PHP is installed as its dependency

There might be other packages required by Yii 2, like php-mcrypt.

For running Yii 2 tests [nineinchnick/pdo_oci8](https://github.com/nineinchnick/pdo_oci8) driver can be used with the following unit test `config.local.php`:

``` php
<?php

$tsn = <<<TSN
(
  DESCRIPTION=(
    ADDRESS_LIST=(
      ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521)
    )
  )(
    CONNECT_DATA=(SID=XE)
  )
)
TSN;
$config['databases']['oci'] = [
    'dsn' => 'oci:dbname='.$tsn.';charset=AL32UTF8;',
    'pdoClass' => 'nineinchnick\pdo\Oci8',
    'username' => 'yiitest',
    'password' => 'yiitest',
    'attributes' => [],
    'fixture' => __DIR__ . '/oci.sql',
];
```
